### PR TITLE
Feature/custom autoscale role

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org' do
   gem 'rake'
   gem 'rspec'
   gem 'rubyzip'
-  gem 'TerraformDevKit', '~> 0.1.9'
+  gem 'TerraformDevKit', '~> 0.3.8'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,54 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    TerraformDevKit (0.1.9)
-      aws-sdk (~> 2.9.37)
-      rubyzip (~> 1.2.1)
-    aws-sdk (2.9.44)
-      aws-sdk-resources (= 2.9.44)
-    aws-sdk-core (2.9.44)
+    TerraformDevKit (0.3.8)
+      aws-sdk-cloudfront (~> 1)
+      aws-sdk-core (~> 3)
+      aws-sdk-dynamodb (~> 1)
+      aws-sdk-s3 (~> 1)
+      mustache (~> 1.0)
+      rainbow (~> 3.0)
+      rubyzip (~> 1.2)
+    aws-eventstream (1.0.1)
+    aws-partitions (1.106.0)
+    aws-sdk-cloudfront (1.10.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-core (3.35.0)
+      aws-eventstream (~> 1.0)
+      aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.44)
-      aws-sdk-core (= 2.9.44)
-    aws-sigv4 (1.0.1)
+    aws-sdk-dynamodb (1.15.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-kms (1.11.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.23.0)
+      aws-sdk-core (~> 3, >= 3.26.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.3)
     diff-lcs (1.3)
-    jmespath (1.3.1)
-    rake (12.0.0)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    jmespath (1.4.0)
+    mustache (1.1.0)
+    rainbow (3.0.0)
+    rake (12.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
-    rubyzip (1.2.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubyzip (1.2.2)
 
 PLATFORMS
   ruby
@@ -37,10 +57,10 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  TerraformDevKit (~> 0.1.9)!
+  TerraformDevKit (~> 0.3.8)!
   rake!
   rspec!
   rubyzip!
 
 BUNDLED WITH
-   1.15.1
+   1.16.3

--- a/modules/dynamodb_autoscale/variables.tf
+++ b/modules/dynamodb_autoscale/variables.tf
@@ -1,36 +1,53 @@
 variable "table_name" {
   description = "Name of the table to add autoscale to"
-
 }
 
 variable "read_autoscale" {
-    description = <<EOF
+  description = <<EOF
     Map containing read autoscale configuration
     
-        default     = {
+    default = {
         enabled = false
         target_value       = 70
         min_capacity       = 1
         max_capacity       = 1
     }
 EOF
-    
-    type        = "map" 
-    default     = {}
+
+  type    = "map"
+  default = {}
 }
 
 variable "write_autoscale" {
-    description = <<EOF
+  description = <<EOF
     Map containing write autoscale configuration
     
-        default     = {
+    default = {
         enabled = false
         target_value       = 70
         min_capacity       = 1
         max_capacity       = 1
     }
 EOF
-    
-    type        = "map" 
-    default = {}
+
+  type    = "map"
+  default = {}
+}
+
+variable "create_role" {
+  description = "Whether to create a specific role and policy"
+
+  default = true
+}
+
+variable "role_arn" {
+  description = "Role ARN to use (if empty a new role will be created)"
+
+  default = ""
+}
+
+variable "policy_id" {
+  description = "Role policy id to depend on"
+
+  default = ""
 }

--- a/scripts/tasks.rake
+++ b/scripts/tasks.rake
@@ -11,7 +11,7 @@ def check_arguments(args)
 end
 
 def add_aws_variables(cmd)
-  aws_config = TDK::AwsConfig.new(TDK::Configuration.get('aws'))
+  aws_config = TDK::Aws::AwsConfig.new(TDK::Configuration.get('aws'))
   profile = aws_config.profile
   region = aws_config.region
   cmd += " -var profile=#{profile}" unless profile.nil?

--- a/test/dynamodb_autoscale/main.tf
+++ b/test/dynamodb_autoscale/main.tf
@@ -1,39 +1,132 @@
 provider "aws" {
-  profile    = "${var.profile}"
-  region     = "${var.region}"
+  profile = "${var.profile}"
+  region  = "${var.region}"
 }
 
 locals {
-    table_info = [
+  table_info = [
     {
-      name = "${var.prefix}Table1"
+      name           = "${var.prefix}Table1"
+      read_capacity  = 1
+      write_capacity = 1
     },
     {
-      name = "${var.prefix}Table2"
-      read_capacity = 2
-      write_capacity = 2
+      name           = "${var.prefix}Table2"
+      read_capacity  = 1
+      write_capacity = 1
+    },
+    {
+      name           = "${var.prefix}Table3"
+      read_capacity  = 1
+      write_capacity = 1
     },
   ]
 }
 
 module "table" {
-  source  = "vistaprint/dynamodb-tables/aws"
-  version = "0.0.1"
+  source     = "vistaprint/dynamodb-tables/aws"
+  version    = "0.0.1"
   table_info = "${local.table_info}"
 }
 
-module "autoscale" {
-    source = "../../modules/dynamodb_autoscale"
+resource "aws_iam_role" "common_dynamodb_autoscale_role" {
+  name = "${var.prefix}_common_autoscale_role"
 
-    table_name = "${element(module.table.names, 1)}"
-
-    read_autoscale = {
-        enabled = true
-
-        # if min/max capacity is changed, target_value has to also be changed due to dependency not working
-        # broken: will get fixed with https://github.com/terraform-providers/terraform-provider-aws/issues/538
-        target_value = 50
-        min_capacity = "${lookup(local.table_info[1], "read_capacity")}"
-        max_capacity = 20
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "application-autoscaling.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
     }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "common_autoscaling_role_policy" {
+  name = "${var.prefix}_common_autoscaling_role_policy"
+  role = "${aws_iam_role.common_dynamodb_autoscale_role.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:UpdateTable",
+        "cloudwatch:PutMetricAlarm",
+        "cloudwatch:DescribeAlarms",
+        "cloudwatch:DeleteAlarms"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+module "autoscale_with_provided_role_1" {
+  source = "../../modules/dynamodb_autoscale"
+
+  table_name = "${element(module.table.names, 0)}"
+
+  create_role = false
+  role_arn = "${aws_iam_role.common_dynamodb_autoscale_role.arn}"
+  policy_id = "${aws_iam_role_policy.common_autoscaling_role_policy.id}"
+
+  read_autoscale = {
+    enabled = true
+
+    # if min/max capacity is changed, target_value has to also be changed due to dependency not working
+    # broken: will get fixed with https://github.com/terraform-providers/terraform-provider-aws/issues/538
+    target_value = 75
+
+    min_capacity = "${lookup(local.table_info[0], "read_capacity")}"
+    max_capacity = 10
+  }
+}
+
+module "autoscale_with_provided_role_2" {
+  source = "../../modules/dynamodb_autoscale"
+
+  table_name = "${element(module.table.names, 1)}"
+
+  create_role = false
+  role_arn = "${aws_iam_role.common_dynamodb_autoscale_role.arn}"
+  policy_id = "${aws_iam_role_policy.common_autoscaling_role_policy.id}"
+
+  read_autoscale = {
+    enabled = true
+
+    # if min/max capacity is changed, target_value has to also be changed due to dependency not working
+    # broken: will get fixed with https://github.com/terraform-providers/terraform-provider-aws/issues/538
+    target_value = 50
+
+    min_capacity = "${lookup(local.table_info[1], "read_capacity")}"
+    max_capacity = 8
+  }
+}
+
+module "autoscale" {
+  source = "../../modules/dynamodb_autoscale"
+
+  table_name = "${element(module.table.names, 2)}"
+
+  read_autoscale = {
+    enabled = true
+
+    # if min/max capacity is changed, target_value has to also be changed due to dependency not working
+    # broken: will get fixed with https://github.com/terraform-providers/terraform-provider-aws/issues/538
+    target_value = 70
+
+    min_capacity = "${lookup(local.table_info[2], "read_capacity")}"
+    max_capacity = 20
+  }
 }

--- a/test/dynamodb_autoscale/rakefile.rb
+++ b/test/dynamodb_autoscale/rakefile.rb
@@ -64,18 +64,48 @@ namespace 'dynamodb_autoscale' do
     })
 
     DynamoDbAutoscaleShould.have_autoscaling_target(
-        client, 
-        "dynamodb", 
-        "table/#{args.prefix}Table2",
-        "dynamodb:table:ReadCapacityUnits",
-        2,
-        20)
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table1",
+      "dynamodb:table:ReadCapacityUnits",
+      1,
+      10)
 
     DynamoDbAutoscaleShould.have_autoscaling_policy(
-        client, 
-        "dynamodb", 
-        "table/#{args.prefix}Table2",
-        "dynamodb:table:ReadCapacityUnits",
-        50)
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table1",
+      "dynamodb:table:ReadCapacityUnits",
+      75)    
+
+    DynamoDbAutoscaleShould.have_autoscaling_target(
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table2",
+      "dynamodb:table:ReadCapacityUnits",
+      1,
+      8)
+
+    DynamoDbAutoscaleShould.have_autoscaling_policy(
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table2",
+      "dynamodb:table:ReadCapacityUnits",
+      50)
+
+    DynamoDbAutoscaleShould.have_autoscaling_target(
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table3",
+      "dynamodb:table:ReadCapacityUnits",
+      1,
+      20)
+
+    DynamoDbAutoscaleShould.have_autoscaling_policy(
+      client, 
+      "dynamodb", 
+      "table/#{args.prefix}Table3",
+      "dynamodb:table:ReadCapacityUnits",
+      70)      
   end
 end

--- a/test/dynamodb_autoscale/rakefile.rb
+++ b/test/dynamodb_autoscale/rakefile.rb
@@ -5,7 +5,6 @@ namespace 'dynamodb_autoscale' do
 
   module DynamoDbAutoscaleShould
     def self.have_autoscaling_target(client, service_namespace, resource_id, scalable_dimension, min_capacity, max_capacity)
-      
       params = {
         service_namespace: service_namespace, 
         resource_ids: [resource_id],
@@ -28,11 +27,9 @@ namespace 'dynamodb_autoscale' do
         puts resp.to_h
         raise 'Incorrect target'
       end
-
     end
 
     def self.have_autoscaling_policy(client, service_namespace, resource_id, scalable_dimension, target_value)
-      
       params = {
         service_namespace: service_namespace, 
         resource_id: resource_id,
@@ -55,13 +52,11 @@ namespace 'dynamodb_autoscale' do
         puts resp.to_h
         raise 'Incorrect policy'
       end
-
     end
   end
 
   task :validate, [:prefix] do |_, args|
-    
-    aws_config = TDK::AwsConfig.new(TDK::Configuration.get('aws'))
+    aws_config = TDK::Aws::AwsConfig.new(TDK::Configuration.get('aws'))
     
     client = Aws::ApplicationAutoScaling::Client.new({ 
       region: aws_config.region, 

--- a/test/lambda/rakefile.rb
+++ b/test/lambda/rakefile.rb
@@ -39,7 +39,7 @@ namespace 'lambda' do
     end
 
     def self.memory_size(function_name)
-      aws_config = TDK::AwsConfig.new(TDK::Configuration.get('aws'))
+      aws_config = TDK::Aws::AwsConfig.new(TDK::Configuration.get('aws'))
       client = Aws::Lambda::Client.new(
         region: aws_config.region,
         credentials: aws_config.credentials


### PR DESCRIPTION
This PR allows for roles to be passed to the dynamodb autoscale module. This is necessary to reduce the number of roles created for "large" deployments.