### PR TITLE
Add output containing the lambda names

### DIFF
--- a/modules/lambda/output.tf
+++ b/modules/lambda/output.tf
@@ -1,3 +1,7 @@
 output "lambda_arns" {
   value = "${zipmap(keys(var.functions), aws_lambda_function.lambda_function.*.arn)}"
 }
+
+output "lambda_names" {
+  value = "${zipmap(keys(var.functions), aws_lambda_function.lambda_function.*.function_name)}"
+}

--- a/test/lambda/main.tf
+++ b/test/lambda/main.tf
@@ -222,3 +222,8 @@ resource "aws_api_gateway_deployment" "deployment" {
 output "api_url" {
   value = "${aws_api_gateway_deployment.deployment.invoke_url}"
 }
+
+# This is just to test that the lambda_names output is created as expected.
+output "lambda_names" {
+  value = "${module.lambdas.lambda_names}"
+}

--- a/test/lambda/rakefile.rb
+++ b/test/lambda/rakefile.rb
@@ -53,6 +53,10 @@ namespace 'lambda' do
       )
       lambda_config.memory_size
     end
+
+    def self.match_names(actual, expected)
+      expect(actual).to eq(expected)
+    end
   end
 
   task :prepare, [:prefix] do
@@ -62,6 +66,17 @@ namespace 'lambda' do
   end
 
   task :validate, [:prefix] do |_, args|
+    lambda_names = TDK::TerraformLogFilter.filter(
+      TDK::Command.run('terraform output lambda_names'))
+
+    LambdaShould.match_names(
+      lambda_names,
+      [
+        "LambdaTestHello = #{args.prefix}LambdaTestHello",
+        "LambdaTestPrintVars = #{args.prefix}LambdaTestPrintVars"
+      ]
+    )
+
     api_url = TDK::TerraformLogFilter.filter(
       TDK::Command.run('terraform output api_url'))[0]
 


### PR DESCRIPTION
Add output to the lambda module containing the name of the functions. Then, these names can be used to directly depend on the creation of the lambdas when their names are needed as an input to another resource.